### PR TITLE
Добавление поддержи ma_listcomms

### DIFF
--- a/addons/sourcemod/configs/materialadmin/config.cfg
+++ b/addons/sourcemod/configs/materialadmin/config.cfg
@@ -300,6 +300,15 @@
 	"CheckBans"				"1"
 
 	/*******RU******
+	Выводить кол-во прошлых блокировок чата для игроков?
+	Плагин: ma_checker
+	********EN******
+	Display count previous blocked comms for players?
+	Plugin: ma_checker
+	*/
+	"CheckComms"				"1"
+
+	/*******RU******
 	Загружать кол-во предупреждений для последующего вывода в админ-меню?
 	Плагин: ma_adminmenu
 	********EN******

--- a/addons/sourcemod/translations/machecker.phrases.txt
+++ b/addons/sourcemod/translations/machecker.phrases.txt
@@ -1,5 +1,29 @@
 "Phrases"
 {
+	"Player connect comm"
+	{
+		"#format"		"{1:s},{2:d}"
+		"en"			"Player \"{1}\" has {2} previous comms"
+		"ru"			"Игрок \"{1}\" имеет {2} мут(а)"
+	}
+	"Listing comms"
+	{
+		"#format"		"{1:s}"
+		"en"    		"List of comms for {1}."
+		"ru"    		"Список мутов для {1}."
+	}
+	"No comms found"
+	{
+		"#format"		"{1:s}"
+		"en"    		"Comms for {1} were not found."
+		"ru"    		"Муты для {1} не найдены."
+	}
+	"DB error while retrieving comms"
+	{
+		"#format"		"{1:s},{2:s}"
+		"en"    		"DB error when getting comms for {1}:\n{2}"
+		"ru"    		"Ошибка БД при получении мутов для {1}:\n {2}"
+	}
 	"Player connect"
 	{
 		"#format"		"{1:s},{2:d}"


### PR DESCRIPTION
Добавил команду ma_listcomms что-бы выводить список мутов и сделал отображение кол-во мутов игрока при входе на сервер. Протестировал на локальном сервере Windows.