### PR TITLE
Добавление форварда MAOnClientReport

### DIFF
--- a/addons/sourcemod/scripting/include/materialadmin.inc
+++ b/addons/sourcemod/scripting/include/materialadmin.inc
@@ -433,3 +433,13 @@ forward void MAOnFindLoadingAdmin(AdminCachePart acPart);
 * @return			true, false
 *********************************************************/
 native bool MALog(int iType, const char[] sLog, any ...);
+
+/*********************************************************
+ * Called when a new report is inserted
+ *
+ * @param iReporter	The client index of the reporter
+ * @param iTarget	The client index of the player to report
+ * @param sReason	The reason to report the player
+ * @noreturn
+ *********************************************************/
+forward void MAOnClientReport(int iClient, int iTarget, char[] sReason);

--- a/addons/sourcemod/scripting/materialadmin/database.sp
+++ b/addons/sourcemod/scripting/materialadmin/database.sp
@@ -1803,7 +1803,10 @@ void SetBdReport(int iClient, const char[] sReason)
 	if (ChekBD(g_dDatabase, "SetBdReport"))
 	{
 		DataPack dPack = new DataPack();
-		dPack.WriteCell(GetClientUserId(iClient));
+		// dPack.WriteCell(GetClientUserId(iClient));
+		dPack.WriteCell(iClient);
+		dPack.WriteCell(iTarget);
+		dPack.WriteString(sReason);
 		dPack.WriteString(sReportName);
 		dPack.WriteString(sQuery);
 		
@@ -1821,7 +1824,13 @@ public void CheckCallbackReport(Database db, DBResultSet dbRs, const char[] sErr
 {
 	DataPack dPack = view_as<DataPack>(data);
 	dPack.Reset();
-	int iClient = GetClientOfUserId(dPack.ReadCell());
+	int iClient = dPack.ReadCell();
+	int iTarget = dPack.ReadCell();
+
+	char sReason[1024];
+
+	dPack.ReadString(sReason, sizeof(sReason));
+
 	char sReportName[MAX_NAME_LENGTH];
 	dPack.ReadString(sReportName, sizeof(sReportName));
 	if (!dbRs || sError[0])
@@ -1836,7 +1845,10 @@ public void CheckCallbackReport(Database db, DBResultSet dbRs, const char[] sErr
 	}
 
 	if (iClient)
+	{
+		FireOnClientReport(iClient, iTarget, sReason);
 		PrintToChat2(iClient, "%T", "Yes report", iClient, sReportName);
+	}
 
 	delete dPack;
 }

--- a/addons/sourcemod/scripting/materialadmin/native.sp
+++ b/addons/sourcemod/scripting/materialadmin/native.sp
@@ -571,3 +571,17 @@ public void BaseComm_OnClientGag(int iClient, bool bState)
 		}
 	}
 }
+
+void FireOnClientReport(int iClient, int iTarget, char[] sReason)
+{
+	static Handle hForward;
+	
+	if(hForward == null)
+		hForward = CreateGlobalForward("MAOnClientReport", ET_Ignore, Param_Cell, Param_Cell, Param_String);
+
+	Call_StartForward(hForward);
+	Call_PushCell(iClient);
+	Call_PushCell(iTarget);
+	Call_PushString(sReason);
+	Call_Finish();
+}


### PR DESCRIPTION
Что делает:
- Добавляет форвард **MAOnClientReport** в апи плагина

Зачем:
- Позволит людям, которые используют MA вместе с каким-нибудь плагинов для пересылки сообщений в дискорд, вк и т.п, пересылать репорты игроков так же, как это сделано в обычном SB

Протестирован на Windows & Linux