### PR TITLE
Фикс времени выданного из веб-бана

### DIFF
--- a/addons/sourcemod/scripting/materialadmin/commands.sp
+++ b/addons/sourcemod/scripting/materialadmin/commands.sp
@@ -883,10 +883,7 @@ public Action CommandWMute(int iArgc)
 	
 	if(iClient)
 	{
-		if (iTime > 0)
-			g_iTargenMuteTime[iClient] = GetTime() + iTime;
-		else
-			g_iTargenMuteTime[iClient] = iTime;
+		g_iTargenMuteTime[iClient] = iTime;
 		strcopy(g_sTargetMuteReason[iClient], sizeof(g_sTargetMuteReason[]), sArg[3]);
 		ReplyToCommand(0, "ok");
 		switch(iType)


### PR DESCRIPTION
Когда выдавался мут с GetTime() + iTime. То мут к примеру, на час выдавался как 19437 дней, что пугало нарушителей и появлялись вопросы. Без GetTime() все работает как надо, скрины до и после

До: https://imgur.com/a/sGTCPQg
После: https://imgur.com/a/LQOgY2Q