### PR TITLE
New plugin ma_novoice

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -42,6 +42,7 @@ jobs:
           spcomp __GITHUB=1 _MATERIALADMIN_BASECOMMS=1 materialadmin.git.sp -E -o ../plugins/ma_basecomm -iinclude ${{ matrix.compiler-options }}
           spcomp __GITHUB=1 _MATERIALADMIN_BASEVOTES=1 materialadmin.git.sp -E -o ../plugins/ma_basevotes -iinclude ${{ matrix.compiler-options }}
           spcomp __GITHUB=1 _MATERIALADMIN_CHECKER=1 materialadmin.git.sp -E -o ../plugins/ma_checker -iinclude ${{ matrix.compiler-options }}
+	spcomp __GITHUB=1 _MATERIALADMIN_NOVOICE=1 materialadmin.git.sp -E -o ../plugins/ma_novoice -iinclude ${{ matrix.compiler-options }}
 
       - name: Cleanup
         if: github.ref == 'refs/heads/master'

--- a/addons/sourcemod/scripting/ma_novoice.sp
+++ b/addons/sourcemod/scripting/ma_novoice.sp
@@ -14,6 +14,12 @@ public Plugin myinfo =
 	url = "https://github.com/CrazyHackGUT/SB_Material_Design/"
 };
 
+public void OnPluginStart()
+{
+	LoadTranslations("common.phrases");
+	LoadTranslations("manovoice.phrases");
+}
+
 public OnClientPutInServer(int client)
 {
 	g_bShowText[client] = false;
@@ -28,7 +34,7 @@ public void OnClientSpeaking(int client)
 		
 		SetHudTextParams(-1.0, -1.0, SHOW_AMOUNT, 0, 255, 127, 255, 1);
 		
-		ShowHudText(client, -1, "У вас выключен голосовой чат!");
+		ShowHudText(client, -1, "%T", "No voice");
 	}
 }
 

--- a/addons/sourcemod/scripting/ma_novoice.sp
+++ b/addons/sourcemod/scripting/ma_novoice.sp
@@ -1,0 +1,42 @@
+#include <sdktools_voice>
+#include <materialadmin>
+
+#define SHOW_AMOUNT 3.0
+
+bool g_bShowText[MAXPLAYERS + 1];
+
+public Plugin myinfo = 
+{
+	name = "Material Admin No Voice", 
+	author = "Bloomstorm", 
+	description = "Check if client has mute and display it to him.", 
+	version = MAVERSION, 
+	url = "https://github.com/CrazyHackGUT/SB_Material_Design/"
+};
+
+public OnClientPutInServer(int client)
+{
+	g_bShowText[client] = false;
+}
+
+public void OnClientSpeaking(int client)
+{
+	if (!g_bShowText[client] && (MAGetClientMuteType(client) == 1 || MAGetClientMuteType(client) == 3))
+	{
+		g_bShowText[client] = true;
+		CreateTimer(SHOW_AMOUNT, Timer_ShowText, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+		
+		SetHudTextParams(-1.0, -1.0, SHOW_AMOUNT, 0, 255, 127, 255, 1);
+		
+		ShowHudText(client, -1, "У вас выключен голосовой чат!");
+	}
+}
+
+public Action Timer_ShowText(Handle timer, int userid)
+{
+	int client = GetClientOfUserId(userid);
+	if (client <= 0)
+		return Plugin_Stop;
+	g_bShowText[client] = false;
+	return Plugin_Stop;
+}

--- a/addons/sourcemod/translations/manovoice.phrases.txt
+++ b/addons/sourcemod/translations/manovoice.phrases.txt
@@ -1,0 +1,8 @@
+"Phrases"
+{
+	"No voice"
+	{
+		"en"    		"Your voice chat is turned off!"
+		"ru"    		"У вас выключен голосовой чат!"
+	}
+}

--- a/ci_sm11.sp
+++ b/ci_sm11.sp
@@ -21,3 +21,7 @@
 #if defined _MATERIALADMIN_CHECKER
     #include "ma_checker.sp"
 #endif
+
+#if defined _MATERIALADMIN_NOVOICE
+    #include "ma_novoice.sp"
+#endif


### PR DESCRIPTION
Новый плагин ma_novoice, суть плагина заключается в том, что когда у игрока мут или сайленс, то ему на весь экран высветится табличка "У вас выключен голосовой чат!", таким образом нарушитель будет знать что у него мут, и не будет балалакать в микрофон и спрашивать у себя "почему меня никто не слышит? микрофон сломался?".

Изначально я планировал еще добавить отображение причины и на сколько отключен микрофон, но в materialadmin.inc такие методы отсутствовали, а #include "materialadmin.sp" выдавал ошибки связанный с DEBUG, поэтому пока так. Если будет добавлены нужные методы (получение причины и срок), то я обновлю плагин.

Протестировал в TF2, вроде бы все норм, в остальных играх не знаю, для отображение текста используется ShowHudText

Скриншот работоспособности https://imgur.com/a/Og6lOux